### PR TITLE
Fix CVE-2025-27363 (freetype) - TDATAINFRA-2211

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ New features:
 2. Update Dockerfile with the desired version of Cruise Control:
    ```
    ARG CC_TAG=renyu/sc-842448/feature/support-amazon-managed-service-for-prometheus
-   
+
    RUN yum install -y wget git tar                                                                                           && \
     git clone -b ${CC_TAG} https://github.com/adRise/cruise-control.git                                           && \
     wget https://github.com/linkedin/cruise-control-ui/releases/download/v${CC_UI_TAG}/cruise-control-ui-${CC_UI_TAG}.tar.gz && \
@@ -20,11 +20,15 @@ New features:
     mv cruise-control-ui cruise-control/                                                                                     && \
     rm -f cruise-control*.tar.gz
    ```
+   To fix CVE-2025-27363 (freetype), add the following in the runtime stage of the Dockerfile:
+   ```
+   RUN yum update -y freetype && yum clean all && rm -rf /var/cache/yum
+   ```
 3. Build the image:
    ```
     docker buildx build --platform linux/amd64 -t 370025973162.dkr.ecr.us-east-2.amazonaws.com/cruise-control:jdk17-cc2.5.141-iam2.2-v1.0 .
     ```
 4. Push the image to ECR:
    ```
-   docker push 370025973162.dkr.ecr.us-east-2.amazonaws.com/cruise-control:jdk17-cc2.5.141-iam2.2-v1.0 
+   docker push 370025973162.dkr.ecr.us-east-2.amazonaws.com/cruise-control:jdk17-cc2.5.141-iam2.2-v1.0
    ```


### PR DESCRIPTION
## Summary
- Added documentation on how to patch OS-level CVEs without rebuilding cruise-control from source
- Recorded the freetype CVE-2025-27363 fix (`2.8-14.amzn2.1.2` → `2.8-14.amzn2.1.4`)
- New image tag: `jdk17-cc2.5.151-iam2.2`

## Context
CVE-2025-27363 is a vulnerability in the freetype package. The fix was applied by layering `yum update -y freetype` on top of the existing `jdk17-cc2.5.149-iam2.2` image.

## JIRA
TDATAINFRA-2211

## Test plan
- [x] Built image locally with `podman build`
- [x] Verified freetype updated to `2.8-14.amzn2.1.4`
- [ ] Push image `jdk17-cc2.5.151-iam2.2` to ECR
- [ ] Update deployments in EKS infra staging, scalamigo staging & production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update; no production code or build artifacts are changed. Risk is limited to potential confusion if the documented Dockerfile steps or image tags drift from reality.
> 
> **Overview**
> Updates `README.md` to document an OS-level mitigation for **CVE-2025-27363** by adding a `yum update -y freetype` step (plus cleanup) to the Dockerfile runtime stage, and fixes minor formatting/whitespace in the image push instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3976711bc1557627310c466c431ab87d6f6c36b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->